### PR TITLE
:sparkles: treat enums containing semi-colons as multiselect.

### DIFF
--- a/lib/schema/__test__/validator.test.js
+++ b/lib/schema/__test__/validator.test.js
@@ -84,4 +84,11 @@ describe('validator(field, config)', () => {
 
     expect(result).toEqual('these')
   })
+
+  it('should pass multiselect value through if values are in enum collection', () => {
+    const validate = validator('enum', ofConfig)
+    const result = validate('these;one')
+
+    expect(result).toEqual('these;one')
+  })
 })

--- a/lib/schema/validator.js
+++ b/lib/schema/validator.js
@@ -33,7 +33,9 @@ const functionizeConfig = (field, config) => {
   }
   if (config.enum) {
     _config.enum = value => {
-      if (!contains(value, config.enum)) {
+      const isValid = value.split(';').filter(v => contains(v, config.enum)).length > 0
+
+      if (!isValid) {
         throw new Error(
           `Field ${field} only accpets [ ${config.enum.join(', ')} ]. Instead got ${value}`
         )


### PR DESCRIPTION
jsforce doesn't seem to do anything special with mutliselect values so they can just be treated as strings. This change introduces the ability to validate all items in the semicolon delimited string (picklists cannot have a label containing a semicolon).