### PR TITLE
:bug: don't set the "required" closure to false

### DIFF
--- a/lib/schema/validator.js
+++ b/lib/schema/validator.js
@@ -52,13 +52,12 @@ const functionizeConfig = (field, config) => {
       throw new Error(`Field: ${field} is expecting type: ${config.type}`)
     }
   }
-  if (config.required) {
-    _config.required = value => {
-      if (value === undefined || value === null) {
-        throw new Error(`Required field: ${field} does not have a value set`)
-      } else {
-        return value
-      }
+
+  _config.required = value => {
+    if (config.required && (value === undefined || value === null)) {
+      throw new Error(`Required field: ${field} does not have a value set`)
+    } else {
+      return value
     }
   }
   return _config


### PR DESCRIPTION
If `required` is set to false, the final validator fails because it is not a closure (but a bool false). 